### PR TITLE
Fixed ext8 serialization

### DIFF
--- a/lib/src/serializer.dart
+++ b/lib/src/serializer.dart
@@ -192,7 +192,7 @@ class Serializer {
         _writer.writeUint8(0xd8);
       } else if (length <= 0xFF) {
         _writer.writeUint8(0xc7);
-        _writer.writeUint16(length);
+        _writer.writeUint8(length);
       } else if (length <= 0xFFFF) {
         _writer.writeUint8(0xc8);
         _writer.writeUint16(length);


### PR DESCRIPTION
The length write for ext8 (0xc7) should be uint8 when serializing, [spec](https://github.com/msgpack/msgpack/blob/master/spec.md).

Deserializer works correctly.
```dart
      case 0xc7:
        return _readExt(_readUInt8());
```