### PR TITLE
Remove dependency on dart:io

### DIFF
--- a/lib/msgpack_dart.dart
+++ b/lib/msgpack_dart.dart
@@ -1,7 +1,6 @@
 library msgpack_dart;
 
 import 'dart:convert';
-import 'dart:io';
 import 'dart:typed_data';
 
 part 'src/common.dart';


### PR DESCRIPTION
This makes the library compatible with web. Also, it didn't use `dart:io` at all. Tests and benchmarks pass after removing `dart:io`

![image](https://user-images.githubusercontent.com/15605299/111906449-a097a980-8a76-11eb-8959-4f153fb02c39.png)
